### PR TITLE
"extraParameters" upgrade sponsored by Orgânica Digital

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The `load` function starts **utmkeeper** and makes all the magic and it can rece
   forceOriginUTM: true,
   fillForms: true,
   utmObject: {},
+  extraParameters: [],
   postLoad: null,
 }
 ```
@@ -29,6 +30,7 @@ The `load` function starts **utmkeeper** and makes all the magic and it can rece
 - **forceOriginUTM**: if `true` the url utms of the page will override any utm present at the links and forms
 - **fillForms**: if `true` all forms will be added the utms, if it does not have the inputs for that hidden ones will be created
 - **utmObject**: an `object` where the utms will be stored, you can use it to send initial utm values to the **utmkeeper**, if it collides with a url UTM it will be overridden 
+- **extraParameters**: an `array` where extra parameters to be persisted across requests, not only "utm_*"
 - **postLoad**: receives a function with one parameter, that function will be runned at the end of load passing an `object` with the parsed utms of the url to run any custom logic
 
 One example of calling `load` with the post load function will be like this:
@@ -38,8 +40,10 @@ utmkeeper.load({
   forceOriginUTM: true,
   fillForms: true,
   utmObject: {
-    utm_test: 'test'
+    utm_test: 'test',
+    parameterA: 'extra-test',
   },
+  extraParameters: ['parameterA', 'parameterB'],
   postLoad: function(utms){console.log(utms);}
 });
 ```

--- a/demo/index.html
+++ b/demo/index.html
@@ -49,9 +49,9 @@
         fillForms: true,
         utmObject: {
           utm_test: 'test',
-          extra1: 'extra1',
+          parameterA: 'extra-test',
         },
-        extraParameters: ['extra1', 'extra2'],
+        extraParameters: ['parameterA', 'parameterB'],
         postLoad: function(utms){console.log(utms);}
       });
     </script>

--- a/demo/index.html
+++ b/demo/index.html
@@ -48,8 +48,10 @@
         forceOriginUTM: true,
         fillForms: true,
         utmObject: {
-          utm_test: 'test'
+          utm_test: 'test',
+          extra1: 'extra1',
         },
+        extraParameters: ['extra1', 'extra2'],
         postLoad: function(utms){console.log(utms);}
       });
     </script>

--- a/src/utmkeeper.js
+++ b/src/utmkeeper.js
@@ -8,6 +8,8 @@ var utmkeeper = {};
     fillForms: true,
     // starting utm object to start the parsing with a custom set of utms
     utmObject: {},
+    // extra parameters to be persisted across requests, not only "utm_*"
+    extraParameters: [],
     // post load function that receives a object as parameter
     // to run custom logic after utm processing. Example:
     // function(utms) {
@@ -33,9 +35,7 @@ var utmkeeper = {};
     }
 
     // take `extraParameters` from config
-    // but have it as array
-    // if empty then empty array ( [] )
-    var extraParameters = config.extraParameters || [];
+    var extraParameters = config.extraParameters;
 
     // we'll store the parameters here
     var obj = {};

--- a/src/utmkeeper.js
+++ b/src/utmkeeper.js
@@ -32,6 +32,11 @@ var utmkeeper = {};
       queryString = window.location.search.slice(1);
     }
 
+    // take `extraParameters` from config
+    // but have it as array
+    // if empty then empty array ( [] )
+    var extraParameters = config.extraParameters || [];
+
     // we'll store the parameters here
     var obj = {};
 
@@ -67,7 +72,11 @@ var utmkeeper = {};
         }
 
         // extract only if matches the filter and has value
-        if (paramName.startsWith(prefix) && paramValue) {
+        if (
+          paramValue &&
+          // start with `prefix` or one of `extraParameters`
+          (paramName.startsWith(prefix) || extraParameters.includes(paramName))
+        ) {
           // if parameter name already exists
           if (obj[paramName]) {
             // convert value to array (if still string)


### PR DESCRIPTION
Link: https://www.organicadigital.com/

----
### Problem

We need set some extra parameters to be persisted across requests, not only `utm_*`.
Sample use case below (`extraParameters` needs to be added):
```javascript
utmkeeper.load({
  forceOriginUTM: true,
  fillForms: true,
  utmObject: {
    utm_test: 'test'
  },
  extraParameters: ['parameterA', 'parameterB'],
  postLoad: function(utms){console.log(utms);}
});
```

### Author

| Name | Profile |
|---|---|
| Vakhtangi Gigauri | https://www.freelancer.com/u/vaxogig |
